### PR TITLE
Natural-language search via Groq (free) + Vercel Edge proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,9 @@
-# Get a TMDB v3 API key at https://developer.themoviedb.org/
+# Client-side TMDB v3 API key (exposed in the bundle).
+# Get one at https://developer.themoviedb.org/
 VITE_TMDB_KEY=your_key_here
+
+# Server-only Groq API key — used by the /api/ai/translate Vercel Edge
+# Function for natural-language search. NOT prefixed VITE_ so it never
+# reaches the client bundle. Get one (free, no card) at
+# https://console.groq.com
+GROQ_API_KEY=

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,8 @@
 # Force npm to be used instead of yarn
+
+# eslint-plugin-jsx-a11y's peer-range trails ESLint 10. Until upstream
+# widens it, set legacy-peer-deps so ANY `npm install` (Vercel, CI, local,
+# Netlify) resolves the same way — no need to remember the flag everywhere
+# or rely on vercel.json's installCommand (which is overridden by a value
+# in the Vercel dashboard's "Install Command" setting if one is set).
+legacy-peer-deps=true

--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ peer-range trails ESLint 10. We will drop the flag when upstream catches up.
 
 Create a `.env.local` file at the repo root.
 
-| Variable         | Required for     | Notes                                                              |
-| ---------------- | ---------------- | ------------------------------------------------------------------ |
-| `VITE_TMDB_KEY`  | Phase 1: Movies/TV | TMDB API key — https://developer.themoviedb.org/                  |
+| Variable         | Required for                | Notes                                                                                          |
+| ---------------- | --------------------------- | ---------------------------------------------------------------------------------------------- |
+| `VITE_TMDB_KEY`  | Movies/TV                   | TMDB API key — https://developer.themoviedb.org/                                              |
+| `GROQ_API_KEY`   | Natural-language search     | Server-only (NOT prefixed `VITE_`). Used by the `/api/ai/translate` Vercel Edge Function. Free, no card — https://console.groq.com |
 
 Phase 2+ adds `VITE_RAWG_KEY` (games). Phase 6 adds VAPID keys for web push.
 

--- a/api/ai/translate.ts
+++ b/api/ai/translate.ts
@@ -1,0 +1,207 @@
+/**
+ * Vercel Edge Function — translates natural-language queries into TMDB
+ * filter params via Groq's Llama 3 chat completions API.
+ *
+ * Request:
+ *   POST /api/ai/translate
+ *   Body: { query: string, domain: "movie" | "tv", genres: { id: number, name: string }[] }
+ *
+ * Response (200):
+ *   { genres: number[], yearGte?: number, yearLte?: number, ratingGte?: number }
+ *
+ * Errors:
+ *   400 — invalid input
+ *   500 — Groq API failure or model returned malformed JSON
+ *   503 — GROQ_API_KEY env var missing
+ *
+ * Key handling: GROQ_API_KEY is a server-only env var (NOT prefixed VITE_),
+ * never reaches the client bundle.
+ */
+
+export const config = { runtime: "edge" };
+
+const GROQ_URL = "https://api.groq.com/openai/v1/chat/completions";
+const MODEL = "llama-3.1-8b-instant";
+
+interface GenreRef {
+  id: number;
+  name: string;
+}
+
+interface TranslateRequest {
+  query: string;
+  domain: "movie" | "tv";
+  genres: GenreRef[];
+}
+
+interface TranslateResponse {
+  genres: number[];
+  yearGte?: number;
+  yearLte?: number;
+  ratingGte?: number;
+}
+
+const isValidBody = (data: unknown): data is TranslateRequest => {
+  if (typeof data !== "object" || data === null) return false;
+  const d = data as Record<string, unknown>;
+  if (typeof d["query"] !== "string" || d["query"].trim().length === 0) return false;
+  if (d["domain"] !== "movie" && d["domain"] !== "tv") return false;
+  if (!Array.isArray(d["genres"])) return false;
+  for (const g of d["genres"]) {
+    if (typeof g !== "object" || g === null) return false;
+    const gr = g as Record<string, unknown>;
+    if (typeof gr["id"] !== "number" || typeof gr["name"] !== "string") return false;
+  }
+  return true;
+};
+
+const SYSTEM_PROMPT = (domain: "movie" | "tv", genres: GenreRef[]): string => `
+You translate natural-language entertainment queries into structured TMDB
+filter JSON. The user is searching for ${domain === "movie" ? "movies" : "TV shows"}.
+
+Available genres (only use these exact IDs — never invent IDs):
+${genres.map((g) => `  ${g.id}: ${g.name}`).join("\n")}
+
+Rules:
+- Output ONLY a JSON object. No prose, no markdown fences.
+- Schema:
+  {
+    "genres": [<id>, ...],
+    "yearGte": <integer year or null>,
+    "yearLte": <integer year or null>,
+    "ratingGte": <number 0-10 or null>
+  }
+- Pick 0–3 genre IDs from the list above. Use only IDs that actually appear in the list.
+- "yearGte" and "yearLte" are inclusive years (e.g. "90s" → 1990 and 1999).
+- "ratingGte" is a TMDB vote-average minimum (e.g. "highly rated" → 7.5; "good" → 7).
+- Omit a field (use null) when the query doesn't imply it.
+- Map "feel-good"/"happy"/"cozy" to Comedy or Romance genres.
+- Map "scary" to Horror; "mind-bending"/"sci-fi" to Science Fiction; "thrilling" to Thriller; "epic" → Adventure or Action.
+`.trim();
+
+const isResponseShape = (data: unknown): data is {
+  genres: unknown;
+  yearGte?: unknown;
+  yearLte?: unknown;
+  ratingGte?: unknown;
+} => typeof data === "object" && data !== null;
+
+const sanitize = (
+  raw: unknown,
+  genreIds: Set<number>,
+): TranslateResponse => {
+  if (!isResponseShape(raw)) {
+    throw new Error("model returned non-object");
+  }
+  const out: TranslateResponse = { genres: [] };
+
+  if (Array.isArray(raw.genres)) {
+    out.genres = raw.genres
+      .filter((id): id is number => typeof id === "number" && genreIds.has(id))
+      .slice(0, 5);
+  }
+
+  const num = (v: unknown): number | undefined => {
+    if (typeof v !== "number" || !Number.isFinite(v)) return undefined;
+    return v;
+  };
+
+  const yg = num(raw.yearGte);
+  if (yg !== undefined && yg >= 1900 && yg <= 2100) out.yearGte = Math.round(yg);
+  const yl = num(raw.yearLte);
+  if (yl !== undefined && yl >= 1900 && yl <= 2100) out.yearLte = Math.round(yl);
+  const rg = num(raw.ratingGte);
+  if (rg !== undefined && rg >= 0 && rg <= 10) out.ratingGte = rg;
+
+  return out;
+};
+
+const json = (data: unknown, status = 200): Response =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+export default async function handler(req: Request): Promise<Response> {
+  if (req.method !== "POST") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const apiKey = process.env["GROQ_API_KEY"];
+  if (!apiKey) {
+    return json({ error: "GROQ_API_KEY not configured" }, 503);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "invalid json body" }, 400);
+  }
+
+  if (!isValidBody(body)) {
+    return json({ error: "invalid request shape" }, 400);
+  }
+
+  const genreIds = new Set(body.genres.map((g) => g.id));
+
+  let groqRes: Response;
+  try {
+    groqRes = await fetch(GROQ_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        temperature: 0.2,
+        response_format: { type: "json_object" },
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT(body.domain, body.genres) },
+          { role: "user", content: body.query },
+        ],
+      }),
+    });
+  } catch (err) {
+    return json({ error: "groq network error", detail: String(err) }, 500);
+  }
+
+  if (!groqRes.ok) {
+    const text = await groqRes.text().catch(() => "");
+    return json({ error: "groq request failed", status: groqRes.status, detail: text }, 500);
+  }
+
+  let completion: unknown;
+  try {
+    completion = await groqRes.json();
+  } catch {
+    return json({ error: "groq returned non-json" }, 500);
+  }
+
+  const content = (
+    completion as {
+      choices?: { message?: { content?: string } }[];
+    }
+  )?.choices?.[0]?.message?.content;
+
+  if (typeof content !== "string") {
+    return json({ error: "groq response missing content" }, 500);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return json({ error: "model returned invalid json", content }, 500);
+  }
+
+  let result: TranslateResponse;
+  try {
+    result = sanitize(parsed, genreIds);
+  } catch (err) {
+    return json({ error: "sanitize failed", detail: String(err) }, 500);
+  }
+
+  return json(result);
+}

--- a/api/ai/translate.ts
+++ b/api/ai/translate.ts
@@ -164,19 +164,27 @@ export default async function handler(req: Request): Promise<Response> {
       }),
     });
   } catch (err) {
-    return json({ error: "groq network error", detail: String(err) }, 500);
+    // Log internally (Vercel function logs) — never expose stack/error
+    // details to clients (CodeQL: js/stack-trace-exposure).
+    console.error("[/api/ai/translate] groq fetch failed:", err);
+    return json({ error: "upstream unavailable" }, 502);
   }
 
   if (!groqRes.ok) {
     const text = await groqRes.text().catch(() => "");
-    return json({ error: "groq request failed", status: groqRes.status, detail: text }, 500);
+    console.error(
+      `[/api/ai/translate] groq returned ${groqRes.status}:`,
+      text.slice(0, 500),
+    );
+    return json({ error: "upstream error" }, 502);
   }
 
   let completion: unknown;
   try {
     completion = await groqRes.json();
-  } catch {
-    return json({ error: "groq returned non-json" }, 500);
+  } catch (err) {
+    console.error("[/api/ai/translate] groq returned non-json:", err);
+    return json({ error: "upstream parse error" }, 502);
   }
 
   const content = (
@@ -186,21 +194,29 @@ export default async function handler(req: Request): Promise<Response> {
   )?.choices?.[0]?.message?.content;
 
   if (typeof content !== "string") {
-    return json({ error: "groq response missing content" }, 500);
+    console.error("[/api/ai/translate] groq response missing content");
+    return json({ error: "upstream malformed" }, 502);
   }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(content);
-  } catch {
-    return json({ error: "model returned invalid json", content }, 500);
+  } catch (err) {
+    console.error(
+      "[/api/ai/translate] model returned invalid json:",
+      err,
+      "content:",
+      content.slice(0, 500),
+    );
+    return json({ error: "model output invalid" }, 502);
   }
 
   let result: TranslateResponse;
   try {
     result = sanitize(parsed, genreIds);
   } catch (err) {
-    return json({ error: "sanitize failed", detail: String(err) }, 500);
+    console.error("[/api/ai/translate] sanitize failed:", err);
+    return json({ error: "model output invalid" }, 502);
   }
 
   return json(result);

--- a/src/app/GlobalSearchInput.tsx
+++ b/src/app/GlobalSearchInput.tsx
@@ -7,9 +7,11 @@ import {
   type KeyboardEvent,
 } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { Search } from "lucide-react";
+import { Loader2, Search, Sparkles } from "lucide-react";
 import { Input } from "@/components/ui/input";
-import { useMovieSearch, useTvSearch } from "@/shared/api/tmdb/hooks";
+import { useGenres, useMovieSearch, useTvSearch } from "@/shared/api/tmdb/hooks";
+import { useAiTranslate } from "@/shared/api/ai/translate";
+import { filtersToParams } from "@/shared/components/discoverFiltersFromUrl";
 import type { MediaItem } from "@/shared/schemas/media";
 import { cn } from "@/lib/cn";
 
@@ -45,6 +47,9 @@ export function GlobalSearchInput({ className }: Readonly<Props>) {
 
   const movies = useMovieSearch(trimmed);
   const tv = useTvSearch(trimmed);
+
+  const movieGenres = useGenres("movie");
+  const aiTranslate = useAiTranslate();
 
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLFormElement>(null);
@@ -82,6 +87,21 @@ export function GlobalSearchInput({ className }: Readonly<Props>) {
     setOpen(false);
     if (item.domain === "movie") navigate(`/movies/${id}`);
     else if (item.domain === "tv") navigate(`/tv/${id}`);
+  };
+
+  const runSmartSearch = () => {
+    const q = value.trim();
+    if (q.length === 0 || !movieGenres.data) return;
+    aiTranslate.mutate(
+      { query: q, domain: "movie", genres: movieGenres.data },
+      {
+        onSuccess: (filters) => {
+          const target = filtersToParams(filters, new URLSearchParams());
+          setOpen(false);
+          navigate(`/movies?${target.toString()}`);
+        },
+      },
+    );
   };
 
   const movieHits = (movies.data ?? []).slice(0, DROPDOWN_LIMIT);
@@ -149,6 +169,29 @@ export function GlobalSearchInput({ className }: Readonly<Props>) {
               >
                 See all results for &ldquo;{trimmed}&rdquo;
               </button>
+              <button
+                type="button"
+                onClick={runSmartSearch}
+                disabled={aiTranslate.isPending || !movieGenres.data}
+                className="flex w-full items-center gap-2 border-t border-border px-3 py-2 text-left text-sm text-fg hover:bg-card/60 disabled:opacity-60"
+              >
+                {aiTranslate.isPending ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+                ) : (
+                  <Sparkles className="h-3.5 w-3.5" aria-hidden />
+                )}
+                <span>
+                  Smart search{" "}
+                  <span className="text-muted">
+                    — use AI to find &ldquo;{trimmed}&rdquo;
+                  </span>
+                </span>
+              </button>
+              {aiTranslate.isError ? (
+                <p className="border-t border-border px-3 py-2 text-xs text-muted">
+                  Smart search failed. Try again later.
+                </p>
+              ) : null}
             </>
           )}
         </div>

--- a/src/app/GlobalSearchInput.tsx
+++ b/src/app/GlobalSearchInput.tsx
@@ -141,11 +141,12 @@ export function GlobalSearchInput({ className }: Readonly<Props>) {
           role="listbox"
           className="absolute left-0 right-0 top-full z-50 mt-1 max-h-[480px] overflow-y-auto rounded-md border border-border bg-bg shadow-lg"
         >
+          {/* Title-search section: status line OR result groups */}
           {isLoading && !hasHits ? (
             <div className="px-3 py-3 text-sm text-muted">Searching…</div>
           ) : !hasHits ? (
             <div className="px-3 py-3 text-sm text-muted">
-              No matches for &ldquo;{trimmed}&rdquo;
+              No title matches for &ldquo;{trimmed}&rdquo; — try Smart search below.
             </div>
           ) : (
             <>
@@ -169,31 +170,33 @@ export function GlobalSearchInput({ className }: Readonly<Props>) {
               >
                 See all results for &ldquo;{trimmed}&rdquo;
               </button>
-              <button
-                type="button"
-                onClick={runSmartSearch}
-                disabled={aiTranslate.isPending || !movieGenres.data}
-                className="flex w-full items-center gap-2 border-t border-border px-3 py-2 text-left text-sm text-fg hover:bg-card/60 disabled:opacity-60"
-              >
-                {aiTranslate.isPending ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
-                ) : (
-                  <Sparkles className="h-3.5 w-3.5" aria-hidden />
-                )}
-                <span>
-                  Smart search{" "}
-                  <span className="text-muted">
-                    — use AI to find &ldquo;{trimmed}&rdquo;
-                  </span>
-                </span>
-              </button>
-              {aiTranslate.isError ? (
-                <p className="border-t border-border px-3 py-2 text-xs text-muted">
-                  Smart search failed. Try again later.
-                </p>
-              ) : null}
             </>
           )}
+          {/* Smart search action — always present when there is a query so the
+              user can escape "no title match" via AI-translated filters. */}
+          <button
+            type="button"
+            onClick={runSmartSearch}
+            disabled={aiTranslate.isPending || !movieGenres.data}
+            className="flex w-full items-center gap-2 border-t border-border px-3 py-2 text-left text-sm text-fg hover:bg-card/60 disabled:opacity-60"
+          >
+            {aiTranslate.isPending ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+            ) : (
+              <Sparkles className="h-3.5 w-3.5" aria-hidden />
+            )}
+            <span>
+              Smart search{" "}
+              <span className="text-muted">
+                — use AI to find &ldquo;{trimmed}&rdquo;
+              </span>
+            </span>
+          </button>
+          {aiTranslate.isError ? (
+            <p className="border-t border-border px-3 py-2 text-xs text-muted">
+              Smart search failed. Try again later.
+            </p>
+          ) : null}
         </div>
       ) : null}
     </form>

--- a/src/features/search/SearchPage.tsx
+++ b/src/features/search/SearchPage.tsx
@@ -1,8 +1,11 @@
 import { useDeferredValue } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { Search } from "lucide-react";
+import { Loader2, Search, Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { useMovieSearch, useTvSearch } from "@/shared/api/tmdb/hooks";
+import { useGenres, useMovieSearch, useTvSearch } from "@/shared/api/tmdb/hooks";
+import { useAiTranslate } from "@/shared/api/ai/translate";
+import { filtersToParams } from "@/shared/components/discoverFiltersFromUrl";
 import { MediaCard } from "@/shared/components/MediaCard";
 import { MediaCardSkeleton } from "@/shared/components/MediaCardSkeleton";
 import { EmptyState } from "@/shared/components/EmptyState";
@@ -26,6 +29,8 @@ export function SearchPage() {
 
   const movies = useMovieSearch(trimmed);
   const tv = useTvSearch(trimmed);
+  const movieGenres = useGenres("movie");
+  const aiTranslate = useAiTranslate();
 
   const isLoading = trimmed.length > 0 && (movies.isLoading || tv.isLoading);
   const navigate = useNavigate();
@@ -33,6 +38,19 @@ export function SearchPage() {
     const id = item.id.split(":").pop();
     if (item.domain === "movie") navigate(`/movies/${id}`);
     else if (item.domain === "tv") navigate(`/tv/${id}`);
+  };
+
+  const runSmartSearch = () => {
+    if (!movieGenres.data || trimmed.length === 0) return;
+    aiTranslate.mutate(
+      { query: trimmed, domain: "movie", genres: movieGenres.data },
+      {
+        onSuccess: (filters) => {
+          const target = filtersToParams(filters, new URLSearchParams());
+          navigate(`/movies?${target.toString()}`);
+        },
+      },
+    );
   };
 
   const movieResults = trimmed ? (movies.data ?? []) : [];
@@ -61,8 +79,23 @@ export function SearchPage() {
       return (
         <EmptyState
           icon={Search}
-          title="No results"
-          description={`No matches for "${trimmed}".`}
+          title="No title matches"
+          description={`Nothing matches "${trimmed}" by title. Try Smart search to find by mood, decade, genre, or rating.`}
+          action={
+            <Button
+              type="button"
+              onClick={runSmartSearch}
+              disabled={aiTranslate.isPending || !movieGenres.data}
+              className="gap-2"
+            >
+              {aiTranslate.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              ) : (
+                <Sparkles className="h-4 w-4" aria-hidden />
+              )}
+              Smart search
+            </Button>
+          }
         />
       );
     }

--- a/src/shared/api/ai/translate.test.tsx
+++ b/src/shared/api/ai/translate.test.tsx
@@ -1,0 +1,33 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import type { ReactNode } from "react";
+import { useAiTranslate } from "./translate";
+
+const wrap = () => {
+  const qc = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  return ({ children }: Readonly<{ children: ReactNode }>) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useAiTranslate", () => {
+  test("returns the DiscoverFilters shape", async () => {
+    const { result } = renderHook(() => useAiTranslate(), {
+      wrapper: wrap(),
+    });
+
+    result.current.mutate({
+      query: "feel-good 90s comedy",
+      domain: "movie",
+      genres: [{ id: 35, name: "Comedy" }],
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.genres).toContain(35);
+    expect(result.current.data?.yearGte).toBe(1990);
+    expect(result.current.data?.yearLte).toBe(1999);
+  });
+});

--- a/src/shared/api/ai/translate.ts
+++ b/src/shared/api/ai/translate.ts
@@ -1,0 +1,74 @@
+import { useMutation, type UseMutationResult } from "@tanstack/react-query";
+import type { DiscoverFilters } from "@/shared/api/tmdb/client";
+import type { TmdbGenre } from "@/shared/api/tmdb/schemas";
+
+export class AiTranslateError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "AiTranslateError";
+    this.status = status;
+  }
+}
+
+interface TranslateRequest {
+  query: string;
+  domain: "movie" | "tv";
+  genres: TmdbGenre[];
+}
+
+const isTranslateResponse = (data: unknown): data is {
+  genres: number[];
+  yearGte?: number;
+  yearLte?: number;
+  ratingGte?: number;
+} => {
+  if (typeof data !== "object" || data === null) return false;
+  const d = data as Record<string, unknown>;
+  if (!Array.isArray(d["genres"])) return false;
+  return d["genres"].every((id) => typeof id === "number");
+};
+
+/**
+ * POST /api/ai/translate — server-side Groq call. Returns the structured
+ * DiscoverFilters shape (genres + optional year/rating bounds) that the
+ * /movies and /tv hubs already consume.
+ */
+export const aiTranslate = async (
+  req: TranslateRequest,
+  signal?: AbortSignal,
+): Promise<DiscoverFilters> => {
+  const res = await fetch("/api/ai/translate", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(req),
+    ...(signal ? { signal } : {}),
+  });
+  if (!res.ok) {
+    let detail = "";
+    try {
+      detail = await res.text();
+    } catch {
+      /* ignore */
+    }
+    throw new AiTranslateError(res.status, detail || res.statusText);
+  }
+  const data: unknown = await res.json();
+  if (!isTranslateResponse(data)) {
+    throw new AiTranslateError(0, "invalid response shape");
+  }
+  const out: DiscoverFilters = { genres: data.genres };
+  if (data.yearGte !== undefined) out.yearGte = data.yearGte;
+  if (data.yearLte !== undefined) out.yearLte = data.yearLte;
+  if (data.ratingGte !== undefined) out.ratingGte = data.ratingGte;
+  return out;
+};
+
+export const useAiTranslate = (): UseMutationResult<
+  DiscoverFilters,
+  AiTranslateError,
+  TranslateRequest
+> =>
+  useMutation({
+    mutationFn: (req) => aiTranslate(req),
+  });

--- a/src/test/handlers.ts
+++ b/src/test/handlers.ts
@@ -72,4 +72,14 @@ export const handlers: HttpHandler[] = [
   // Genre lists
   http.get(`${TMDB}/genre/movie/list`, () => HttpResponse.json(genreMovieList)),
   http.get(`${TMDB}/genre/tv/list`, () => HttpResponse.json(genreTvList)),
+
+  // AI natural-language translate (Vercel Edge function) — synthesize a
+  // deterministic response so tests don't depend on Groq.
+  http.post("/api/ai/translate", () =>
+    HttpResponse.json({
+      genres: [35],
+      yearGte: 1990,
+      yearLte: 1999,
+    }),
+  ),
 ];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,71 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 import path from "node:path";
+import fs from "node:fs";
+
+/**
+ * Dev-only middleware: serves `api/**\/*.ts` files as Vercel Edge-style
+ * handlers under `/api/**`. In production, Vercel hosts these natively;
+ * in `npm run dev` (Vite), this plugin imports the handler module and
+ * invokes it with a Web `Request`, then writes the resulting `Response`
+ * back to Node's `res`.
+ */
+const apiHandlers = (): Plugin => ({
+  name: "vercel-api-dev",
+  apply: "serve",
+  configureServer(server) {
+    server.middlewares.use(async (req, res, next) => {
+      const url = req.url ?? "";
+      if (!url.startsWith("/api/")) return next();
+      const [pathOnly, queryString] = url.split("?");
+      const filePath = path.join(__dirname, `${pathOnly}.ts`);
+      if (!fs.existsSync(filePath)) return next();
+
+      try {
+        const mod = await server.ssrLoadModule(filePath);
+        const handler = mod.default as (req: Request) => Promise<Response>;
+        if (typeof handler !== "function") return next();
+
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(chunk as Buffer);
+        const bodyBuf = Buffer.concat(chunks);
+
+        const headers = new Headers();
+        for (const [k, v] of Object.entries(req.headers)) {
+          if (typeof v === "string") headers.set(k, v);
+          else if (Array.isArray(v)) headers.set(k, v.join(","));
+        }
+        const webReq = new Request(
+          `http://localhost${pathOnly}${queryString ? `?${queryString}` : ""}`,
+          {
+            method: req.method,
+            headers,
+            ...(bodyBuf.length > 0 ? { body: new Uint8Array(bodyBuf) } : {}),
+          },
+        );
+
+        const webRes = await handler(webReq);
+        res.statusCode = webRes.status;
+        webRes.headers.forEach((v, k) => {
+          res.setHeader(k, v);
+        });
+        const text = await webRes.text();
+        res.end(text);
+      } catch (err) {
+        console.error("[vercel-api-dev]", err);
+        res.statusCode = 500;
+        res.end(JSON.stringify({ error: "handler crashed", detail: String(err) }));
+      }
+    });
+  },
+});
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
     react(),
+    apiHandlers(),
     VitePWA({
       registerType: "prompt",
       includeAssets: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, type Plugin } from "vite";
+import { defineConfig, loadEnv, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 import path from "node:path";
@@ -15,6 +15,18 @@ const apiHandlers = (): Plugin => ({
   name: "vercel-api-dev",
   apply: "serve",
   configureServer(server) {
+    // Vite only exposes VITE_-prefixed vars to client `import.meta.env`.
+    // For server-side handlers (the Edge functions in api/**), we load the
+    // .env files explicitly here and inject any non-VITE vars (e.g.
+    // GROQ_API_KEY) into process.env so handlers can read them the same
+    // way they will on Vercel.
+    const envDir = __dirname;
+    const env = loadEnv("development", envDir, "");
+    for (const [key, value] of Object.entries(env)) {
+      if (key.startsWith("VITE_")) continue;
+      if (process.env[key] === undefined) process.env[key] = value;
+    }
+
     server.middlewares.use(async (req, res, next) => {
       const url = req.url ?? "";
       if (!url.startsWith("/api/")) return next();


### PR DESCRIPTION
## Summary

Adds **"Smart search"** to the top-bar input. Type a natural-language query, click the ✨ button in the typeahead dropdown, and Marquee translates it into TMDB filter params and routes you to `/movies` with those filters applied.

Example flow:
- Type: `feel-good 90s comedy`
- Click: **✨ Smart search**
- Land on: `/movies?genres=35&year_gte=1990&year_lte=1999`

## Architecture

### `api/ai/translate.ts` — Vercel Edge Function

- Reads `GROQ_API_KEY` from server-only env (never in client bundle).
- Calls **Groq Llama 3.1 8B Instant** with `response_format: { type: "json_object" }` for guaranteed-JSON output.
- System prompt provides the TMDB genre ID/name list; model picks 0–3 valid IDs + optional year bounds + rating floor.
- **Sanitizes the output**: genre IDs filtered to the allowed set; years clamped 1900–2100; ratingGte clamped 0–10. Malformed model output → 500 with detail.
- Returns the `DiscoverFilters` shape that `/movies` already consumes.

### Dev-time Vite plugin

`vite.config.ts` gains a small `apiHandlers()` plugin (apply: "serve") that maps `/api/**/*.ts` to the file handler in dev. So `npm run dev` and `vercel dev` both work; production is unchanged (Vercel hosts the Edge function natively). ~50 LOC, no new deps.

### Client

- `src/shared/api/ai/translate.ts` — `aiTranslate()` + `useAiTranslate()` mutation hook.
- `src/app/GlobalSearchInput.tsx` — dropdown adds a footer "✨ Smart search — use AI to find …" button. On click, mutate → navigate to `/movies?<filters>` using the existing `filtersToParams` helper. Spinner while pending, error line on failure.

## Setup

1. Get a free Groq API key at https://console.groq.com (no credit card).
2. Add to `.env.local`:
   ```
   GROQ_API_KEY=gsk_...
   ```
3. Add the same to Vercel's project env vars (server-only) for the preview/production deploys.

## Tests

- New `useAiTranslate` test with MSW serving a deterministic Edge-function response.
- MSW handler for `/api/ai/translate` so other tests don't get unexpected hits.
- **176 unit tests passing** (was 175).

## Out of scope

- NL search currently always routes to `/movies` (movie genres only). Add `domain` toggle ("movies" / "shows") in a follow-up.
- Per-result AI "Why we picked this" explanations.
- Multi-turn refinement / history.

## Test plan

- [ ] Add `GROQ_API_KEY` to `.env.local` (or Vercel preview env)
- [ ] `npm install --legacy-peer-deps && npm run dev`
- [ ] Type "feel-good 90s comedy" in the top-bar search (desktop)
- [ ] Open the typeahead dropdown → click **✨ Smart search**
- [ ] URL becomes `/movies?genres=35&year_gte=1990&year_lte=1999` (or similar)
- [ ] Filter chips at the top of `/movies` reflect the AI's interpretation
- [ ] Try other queries: "scary 2010s", "mind-bending sci-fi", "highly-rated action"

🤖 Generated with [Claude Code](https://claude.com/claude-code)