### PR TITLE
AI-powered "For you" rail on /today

### DIFF
--- a/api/_lib/groq.ts
+++ b/api/_lib/groq.ts
@@ -1,0 +1,137 @@
+/**
+ * Shared helpers for /api/ai/* Vercel Edge Functions. Centralizes the
+ * Groq request pattern, error handling, and response sanitization so each
+ * endpoint can focus on its specific input validation + prompt.
+ *
+ * `_lib/` is ignored as a route by Vercel (leading underscore convention).
+ */
+
+const GROQ_URL = "https://api.groq.com/openai/v1/chat/completions";
+const DEFAULT_MODEL = "llama-3.1-8b-instant";
+
+export const json = (data: unknown, status = 200): Response =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+/**
+ * Internal log prefix tag for each Edge endpoint — keeps the per-endpoint
+ * console.error lines greppable in Vercel function logs.
+ */
+type LogTag = string;
+
+/**
+ * Call Groq's chat completions with JSON mode. On success returns the
+ * parsed JSON the model produced. On any failure (network / non-2xx /
+ * bad parse / missing content), logs server-side and returns a Response
+ * with a generic body that the caller should forward to the client.
+ *
+ * Caller pattern:
+ *   const groqResult = await callGroqJson({ tag, system, user });
+ *   if (groqResult.kind === "error") return groqResult.response;
+ *   // groqResult.kind === "ok": use groqResult.parsed
+ */
+export type GroqJsonResult =
+  | { kind: "ok"; parsed: unknown }
+  | { kind: "error"; response: Response };
+
+export async function callGroqJson(opts: {
+  tag: LogTag;
+  systemPrompt: string;
+  userPrompt: string;
+  temperature?: number;
+  model?: string;
+}): Promise<GroqJsonResult> {
+  const apiKey = process.env["GROQ_API_KEY"];
+  if (!apiKey) {
+    return {
+      kind: "error",
+      response: json({ error: "GROQ_API_KEY not configured" }, 503),
+    };
+  }
+
+  let groqRes: Response;
+  try {
+    groqRes = await fetch(GROQ_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: opts.model ?? DEFAULT_MODEL,
+        temperature: opts.temperature ?? 0.2,
+        response_format: { type: "json_object" },
+        messages: [
+          { role: "system", content: opts.systemPrompt },
+          { role: "user", content: opts.userPrompt },
+        ],
+      }),
+    });
+  } catch (err) {
+    console.error(`[${opts.tag}] groq fetch failed:`, err);
+    return { kind: "error", response: json({ error: "upstream unavailable" }, 502) };
+  }
+
+  if (!groqRes.ok) {
+    const text = await groqRes.text().catch(() => "");
+    console.error(`[${opts.tag}] groq returned ${groqRes.status}:`, text.slice(0, 500));
+    return { kind: "error", response: json({ error: "upstream error" }, 502) };
+  }
+
+  let completion: unknown;
+  try {
+    completion = await groqRes.json();
+  } catch (err) {
+    console.error(`[${opts.tag}] groq returned non-json:`, err);
+    return { kind: "error", response: json({ error: "upstream parse error" }, 502) };
+  }
+
+  const content = (
+    completion as { choices?: { message?: { content?: string } }[] }
+  )?.choices?.[0]?.message?.content;
+
+  if (typeof content !== "string") {
+    console.error(`[${opts.tag}] groq response missing content`);
+    return { kind: "error", response: json({ error: "upstream malformed" }, 502) };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (err) {
+    console.error(
+      `[${opts.tag}] model returned invalid json:`,
+      err,
+      "content:",
+      content.slice(0, 500),
+    );
+    return { kind: "error", response: json({ error: "model output invalid" }, 502) };
+  }
+
+  return { kind: "ok", parsed };
+}
+
+/** Tight numeric guard: must be a finite number in `[min, max]`. */
+export const clampInRange = (
+  v: unknown,
+  min: number,
+  max: number,
+): number | undefined => {
+  if (typeof v !== "number" || !Number.isFinite(v)) return undefined;
+  if (v < min || v > max) return undefined;
+  return v;
+};
+
+/** Filter an unknown-shape array to numeric IDs that appear in `allowed`. */
+export const allowedIds = (
+  raw: unknown,
+  allowed: Set<number>,
+  cap = 5,
+): number[] => {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((id): id is number => typeof id === "number" && allowed.has(id))
+    .slice(0, cap);
+};

--- a/api/ai/recommend.ts
+++ b/api/ai/recommend.ts
@@ -14,21 +14,19 @@
  *   Body: {
  *     domain: "movie" | "tv",
  *     genres: { id: number, name: string }[],
- *     watchlist: { title: string; genres: string[]; year?: number;
- *                  status: "want"|"in_progress"|"done"|"dropped";
- *                  rating?: number }[],
- *     recents: string[]   // titles only
+ *     watchlist: { title, genres, year?, status, rating? }[],
+ *     recents: string[]
  *   }
  *
  * Response (200):
- *   { filters: { genres: number[], yearGte?: number, yearLte?: number,
- *                ratingGte?: number }, reason: string }
+ *   { filters: { genres, yearGte?, yearLte?, ratingGte? }, reason: string }
  */
+
+import { allowedIds, callGroqJson, clampInRange, json } from "../_lib/groq";
 
 export const config = { runtime: "edge" };
 
-const GROQ_URL = "https://api.groq.com/openai/v1/chat/completions";
-const MODEL = "llama-3.1-8b-instant";
+const TAG = "/api/ai/recommend";
 
 interface GenreRef {
   id: number;
@@ -66,7 +64,6 @@ const isValidBody = (data: unknown): data is RecommendRequest => {
   if (d["domain"] !== "movie" && d["domain"] !== "tv") return false;
   if (!Array.isArray(d["genres"]) || !Array.isArray(d["watchlist"])) return false;
   if (!Array.isArray(d["recents"])) return false;
-  // Loose validation — heavy duck-typing would just be ceremony.
   return true;
 };
 
@@ -106,9 +103,9 @@ ${req.recents.length === 0 ? "  (none)" : req.recents.slice(0, 20).map((t) => ` 
 Output ONLY a JSON object. No prose, no markdown fences:
 {
   "filters": {
-    "genres": [<id>, ...],          // 1–3 IDs from the list above
-    "yearGte": <integer or null>,    // earliest year to consider
-    "yearLte": <integer or null>,    // latest year to consider
+    "genres": [<id>, ...],
+    "yearGte": <integer or null>,
+    "yearLte": <integer or null>,
     "ratingGte": <number 0-10 or null>
   },
   "reason": "<one short sentence — what about their profile drove the picks>"
@@ -116,11 +113,10 @@ Output ONLY a JSON object. No prose, no markdown fences:
 
 Guidance:
 - Bias toward the dominant genres / decades / rating bands in their watchlist.
-- If they've rated things ≥4, the ratingGte floor should be ≥7.
+- If they've rated things >=4, the ratingGte floor should be >=7.
 - Don't repeat genres that appear in EVERY watchlist item — pick adjacent ones to broaden discovery.
 - yearGte/yearLte should cover a window of 5–15 years that fits their taste; null = no constraint.
-- Cold start (empty watchlist + empty recents): pick popular, broadly appealing filters
-  (e.g. ratingGte: 7, sort by popularity — but you don't output sort; the client defaults it).
+- Cold start (empty watchlist + empty recents): pick popular, broadly appealing filters.
 - The "reason" should reference specifics (a title, a genre cluster, a decade) — don't be generic.
 `.trim();
 
@@ -128,62 +124,27 @@ const sanitize = (
   raw: unknown,
   allowedGenreIds: Set<number>,
 ): RecommendResponse => {
-  if (typeof raw !== "object" || raw === null) {
-    throw new Error("non-object");
-  }
+  if (typeof raw !== "object" || raw === null) throw new Error("non-object");
   const r = raw as Record<string, unknown>;
   const f =
     typeof r["filters"] === "object" && r["filters"] !== null
       ? (r["filters"] as Record<string, unknown>)
       : {};
-
   const out: RecommendResponse = {
-    filters: { genres: [] },
+    filters: { genres: allowedIds(f["genres"], allowedGenreIds, 5) },
     reason: typeof r["reason"] === "string" ? r["reason"].slice(0, 240) : "",
   };
-
-  if (Array.isArray(f["genres"])) {
-    out.filters.genres = (f["genres"] as unknown[])
-      .filter(
-        (id): id is number => typeof id === "number" && allowedGenreIds.has(id),
-      )
-      .slice(0, 5);
-  }
-
-  const num = (v: unknown): number | undefined =>
-    typeof v === "number" && Number.isFinite(v) ? v : undefined;
-
-  const yg = num(f["yearGte"]);
-  if (yg !== undefined && yg >= 1900 && yg <= 2100) {
-    out.filters.yearGte = Math.round(yg);
-  }
-  const yl = num(f["yearLte"]);
-  if (yl !== undefined && yl >= 1900 && yl <= 2100) {
-    out.filters.yearLte = Math.round(yl);
-  }
-  const rg = num(f["ratingGte"]);
-  if (rg !== undefined && rg >= 0 && rg <= 10) {
-    out.filters.ratingGte = rg;
-  }
-
+  const yg = clampInRange(f["yearGte"], 1900, 2100);
+  if (yg !== undefined) out.filters.yearGte = Math.round(yg);
+  const yl = clampInRange(f["yearLte"], 1900, 2100);
+  if (yl !== undefined) out.filters.yearLte = Math.round(yl);
+  const rg = clampInRange(f["ratingGte"], 0, 10);
+  if (rg !== undefined) out.filters.ratingGte = rg;
   return out;
 };
 
-const json = (data: unknown, status = 200): Response =>
-  new Response(JSON.stringify(data), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
-
 export default async function handler(req: Request): Promise<Response> {
-  if (req.method !== "POST") {
-    return json({ error: "method not allowed" }, 405);
-  }
-
-  const apiKey = process.env["GROQ_API_KEY"];
-  if (!apiKey) {
-    return json({ error: "GROQ_API_KEY not configured" }, 503);
-  }
+  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
 
   let body: unknown;
   try {
@@ -198,72 +159,19 @@ export default async function handler(req: Request): Promise<Response> {
 
   const allowedGenreIds = new Set(body.genres.map((g) => g.id));
 
-  let groqRes: Response;
-  try {
-    groqRes = await fetch(GROQ_URL, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: MODEL,
-        temperature: 0.4,
-        response_format: { type: "json_object" },
-        messages: [
-          { role: "system", content: SYSTEM_PROMPT(body.domain, body.genres, body) },
-          { role: "user", content: "Pick a filter and explain." },
-        ],
-      }),
-    });
-  } catch (err) {
-    console.error("[/api/ai/recommend] groq fetch failed:", err);
-    return json({ error: "upstream unavailable" }, 502);
-  }
-
-  if (!groqRes.ok) {
-    const text = await groqRes.text().catch(() => "");
-    console.error(
-      `[/api/ai/recommend] groq returned ${groqRes.status}:`,
-      text.slice(0, 500),
-    );
-    return json({ error: "upstream error" }, 502);
-  }
-
-  let completion: unknown;
-  try {
-    completion = await groqRes.json();
-  } catch (err) {
-    console.error("[/api/ai/recommend] groq returned non-json:", err);
-    return json({ error: "upstream parse error" }, 502);
-  }
-
-  const content = (
-    completion as { choices?: { message?: { content?: string } }[] }
-  )?.choices?.[0]?.message?.content;
-
-  if (typeof content !== "string") {
-    console.error("[/api/ai/recommend] groq response missing content");
-    return json({ error: "upstream malformed" }, 502);
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(content);
-  } catch (err) {
-    console.error(
-      "[/api/ai/recommend] model returned invalid json:",
-      err,
-      content.slice(0, 500),
-    );
-    return json({ error: "model output invalid" }, 502);
-  }
+  const groqResult = await callGroqJson({
+    tag: TAG,
+    systemPrompt: SYSTEM_PROMPT(body.domain, body.genres, body),
+    userPrompt: "Pick a filter and explain.",
+    temperature: 0.4,
+  });
+  if (groqResult.kind === "error") return groqResult.response;
 
   let result: RecommendResponse;
   try {
-    result = sanitize(parsed, allowedGenreIds);
+    result = sanitize(groqResult.parsed, allowedGenreIds);
   } catch (err) {
-    console.error("[/api/ai/recommend] sanitize failed:", err);
+    console.error(`[${TAG}] sanitize failed:`, err);
     return json({ error: "model output invalid" }, 502);
   }
 

--- a/api/ai/recommend.ts
+++ b/api/ai/recommend.ts
@@ -1,0 +1,271 @@
+/**
+ * Vercel Edge Function — generates a personalized TMDB discover filter
+ * based on a user's watchlist + recently-viewed signals, via Groq.
+ *
+ * The client sends the user's local profile (titles, genres, years,
+ * statuses, ratings) — never IDs that could be reused for tracking, never
+ * anything stored server-side. The server forwards a summarized version to
+ * Groq, gets back a structured filter + a one-line reason, sanitizes it,
+ * and returns. The client then runs that filter through TMDB discover
+ * (existing hooks) to surface real items.
+ *
+ * Request:
+ *   POST /api/ai/recommend
+ *   Body: {
+ *     domain: "movie" | "tv",
+ *     genres: { id: number, name: string }[],
+ *     watchlist: { title: string; genres: string[]; year?: number;
+ *                  status: "want"|"in_progress"|"done"|"dropped";
+ *                  rating?: number }[],
+ *     recents: string[]   // titles only
+ *   }
+ *
+ * Response (200):
+ *   { filters: { genres: number[], yearGte?: number, yearLte?: number,
+ *                ratingGte?: number }, reason: string }
+ */
+
+export const config = { runtime: "edge" };
+
+const GROQ_URL = "https://api.groq.com/openai/v1/chat/completions";
+const MODEL = "llama-3.1-8b-instant";
+
+interface GenreRef {
+  id: number;
+  name: string;
+}
+
+interface WatchlistEntry {
+  title: string;
+  genres: string[];
+  year?: number;
+  status: "want" | "in_progress" | "done" | "dropped";
+  rating?: number;
+}
+
+interface RecommendRequest {
+  domain: "movie" | "tv";
+  genres: GenreRef[];
+  watchlist: WatchlistEntry[];
+  recents: string[];
+}
+
+interface RecommendResponse {
+  filters: {
+    genres: number[];
+    yearGte?: number;
+    yearLte?: number;
+    ratingGte?: number;
+  };
+  reason: string;
+}
+
+const isValidBody = (data: unknown): data is RecommendRequest => {
+  if (typeof data !== "object" || data === null) return false;
+  const d = data as Record<string, unknown>;
+  if (d["domain"] !== "movie" && d["domain"] !== "tv") return false;
+  if (!Array.isArray(d["genres"]) || !Array.isArray(d["watchlist"])) return false;
+  if (!Array.isArray(d["recents"])) return false;
+  // Loose validation — heavy duck-typing would just be ceremony.
+  return true;
+};
+
+const formatWatchlist = (entries: WatchlistEntry[]): string => {
+  if (entries.length === 0) return "(empty)";
+  return entries
+    .slice(0, 20)
+    .map((e) => {
+      const facets: string[] = [];
+      if (e.year !== undefined) facets.push(`${e.year}`);
+      if (e.genres.length > 0) facets.push(e.genres.slice(0, 3).join("/"));
+      facets.push(e.status);
+      if (e.rating !== undefined) facets.push(`rated ${e.rating}/5`);
+      return `  - ${e.title} (${facets.join(", ")})`;
+    })
+    .join("\n");
+};
+
+const SYSTEM_PROMPT = (
+  domain: "movie" | "tv",
+  genres: GenreRef[],
+  req: RecommendRequest,
+): string => `
+You translate a user's entertainment taste profile into a TMDB discover
+filter that will surface NEW ${domain === "movie" ? "movies" : "TV shows"}
+they will likely enjoy.
+
+Available genres (use ONLY these exact IDs):
+${genres.map((g) => `  ${g.id}: ${g.name}`).join("\n")}
+
+User's watchlist:
+${formatWatchlist(req.watchlist)}
+
+Recently viewed titles:
+${req.recents.length === 0 ? "  (none)" : req.recents.slice(0, 20).map((t) => `  - ${t}`).join("\n")}
+
+Output ONLY a JSON object. No prose, no markdown fences:
+{
+  "filters": {
+    "genres": [<id>, ...],          // 1–3 IDs from the list above
+    "yearGte": <integer or null>,    // earliest year to consider
+    "yearLte": <integer or null>,    // latest year to consider
+    "ratingGte": <number 0-10 or null>
+  },
+  "reason": "<one short sentence — what about their profile drove the picks>"
+}
+
+Guidance:
+- Bias toward the dominant genres / decades / rating bands in their watchlist.
+- If they've rated things ≥4, the ratingGte floor should be ≥7.
+- Don't repeat genres that appear in EVERY watchlist item — pick adjacent ones to broaden discovery.
+- yearGte/yearLte should cover a window of 5–15 years that fits their taste; null = no constraint.
+- Cold start (empty watchlist + empty recents): pick popular, broadly appealing filters
+  (e.g. ratingGte: 7, sort by popularity — but you don't output sort; the client defaults it).
+- The "reason" should reference specifics (a title, a genre cluster, a decade) — don't be generic.
+`.trim();
+
+const sanitize = (
+  raw: unknown,
+  allowedGenreIds: Set<number>,
+): RecommendResponse => {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("non-object");
+  }
+  const r = raw as Record<string, unknown>;
+  const f =
+    typeof r["filters"] === "object" && r["filters"] !== null
+      ? (r["filters"] as Record<string, unknown>)
+      : {};
+
+  const out: RecommendResponse = {
+    filters: { genres: [] },
+    reason: typeof r["reason"] === "string" ? r["reason"].slice(0, 240) : "",
+  };
+
+  if (Array.isArray(f["genres"])) {
+    out.filters.genres = (f["genres"] as unknown[])
+      .filter(
+        (id): id is number => typeof id === "number" && allowedGenreIds.has(id),
+      )
+      .slice(0, 5);
+  }
+
+  const num = (v: unknown): number | undefined =>
+    typeof v === "number" && Number.isFinite(v) ? v : undefined;
+
+  const yg = num(f["yearGte"]);
+  if (yg !== undefined && yg >= 1900 && yg <= 2100) {
+    out.filters.yearGte = Math.round(yg);
+  }
+  const yl = num(f["yearLte"]);
+  if (yl !== undefined && yl >= 1900 && yl <= 2100) {
+    out.filters.yearLte = Math.round(yl);
+  }
+  const rg = num(f["ratingGte"]);
+  if (rg !== undefined && rg >= 0 && rg <= 10) {
+    out.filters.ratingGte = rg;
+  }
+
+  return out;
+};
+
+const json = (data: unknown, status = 200): Response =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+export default async function handler(req: Request): Promise<Response> {
+  if (req.method !== "POST") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const apiKey = process.env["GROQ_API_KEY"];
+  if (!apiKey) {
+    return json({ error: "GROQ_API_KEY not configured" }, 503);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "invalid json body" }, 400);
+  }
+
+  if (!isValidBody(body)) {
+    return json({ error: "invalid request shape" }, 400);
+  }
+
+  const allowedGenreIds = new Set(body.genres.map((g) => g.id));
+
+  let groqRes: Response;
+  try {
+    groqRes = await fetch(GROQ_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        temperature: 0.4,
+        response_format: { type: "json_object" },
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT(body.domain, body.genres, body) },
+          { role: "user", content: "Pick a filter and explain." },
+        ],
+      }),
+    });
+  } catch (err) {
+    console.error("[/api/ai/recommend] groq fetch failed:", err);
+    return json({ error: "upstream unavailable" }, 502);
+  }
+
+  if (!groqRes.ok) {
+    const text = await groqRes.text().catch(() => "");
+    console.error(
+      `[/api/ai/recommend] groq returned ${groqRes.status}:`,
+      text.slice(0, 500),
+    );
+    return json({ error: "upstream error" }, 502);
+  }
+
+  let completion: unknown;
+  try {
+    completion = await groqRes.json();
+  } catch (err) {
+    console.error("[/api/ai/recommend] groq returned non-json:", err);
+    return json({ error: "upstream parse error" }, 502);
+  }
+
+  const content = (
+    completion as { choices?: { message?: { content?: string } }[] }
+  )?.choices?.[0]?.message?.content;
+
+  if (typeof content !== "string") {
+    console.error("[/api/ai/recommend] groq response missing content");
+    return json({ error: "upstream malformed" }, 502);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (err) {
+    console.error(
+      "[/api/ai/recommend] model returned invalid json:",
+      err,
+      content.slice(0, 500),
+    );
+    return json({ error: "model output invalid" }, 502);
+  }
+
+  let result: RecommendResponse;
+  try {
+    result = sanitize(parsed, allowedGenreIds);
+  } catch (err) {
+    console.error("[/api/ai/recommend] sanitize failed:", err);
+    return json({ error: "model output invalid" }, 502);
+  }
+
+  return json(result);
+}

--- a/api/ai/translate.ts
+++ b/api/ai/translate.ts
@@ -11,17 +11,18 @@
  *
  * Errors:
  *   400 — invalid input
- *   500 — Groq API failure or model returned malformed JSON
+ *   502 — Groq upstream / malformed output
  *   503 — GROQ_API_KEY env var missing
  *
  * Key handling: GROQ_API_KEY is a server-only env var (NOT prefixed VITE_),
  * never reaches the client bundle.
  */
 
+import { allowedIds, callGroqJson, clampInRange, json } from "../_lib/groq";
+
 export const config = { runtime: "edge" };
 
-const GROQ_URL = "https://api.groq.com/openai/v1/chat/completions";
-const MODEL = "llama-3.1-8b-instant";
+const TAG = "/api/ai/translate";
 
 interface GenreRef {
   id: number;
@@ -79,58 +80,28 @@ Rules:
 - Map "scary" to Horror; "mind-bending"/"sci-fi" to Science Fiction; "thrilling" to Thriller; "epic" → Adventure or Action.
 `.trim();
 
-const isResponseShape = (data: unknown): data is {
-  genres: unknown;
-  yearGte?: unknown;
-  yearLte?: unknown;
-  ratingGte?: unknown;
-} => typeof data === "object" && data !== null;
-
 const sanitize = (
   raw: unknown,
   genreIds: Set<number>,
 ): TranslateResponse => {
-  if (!isResponseShape(raw)) {
-    throw new Error("model returned non-object");
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("non-object");
   }
-  const out: TranslateResponse = { genres: [] };
-
-  if (Array.isArray(raw.genres)) {
-    out.genres = raw.genres
-      .filter((id): id is number => typeof id === "number" && genreIds.has(id))
-      .slice(0, 5);
-  }
-
-  const num = (v: unknown): number | undefined => {
-    if (typeof v !== "number" || !Number.isFinite(v)) return undefined;
-    return v;
+  const r = raw as Record<string, unknown>;
+  const out: TranslateResponse = {
+    genres: allowedIds(r["genres"], genreIds, 5),
   };
-
-  const yg = num(raw.yearGte);
-  if (yg !== undefined && yg >= 1900 && yg <= 2100) out.yearGte = Math.round(yg);
-  const yl = num(raw.yearLte);
-  if (yl !== undefined && yl >= 1900 && yl <= 2100) out.yearLte = Math.round(yl);
-  const rg = num(raw.ratingGte);
-  if (rg !== undefined && rg >= 0 && rg <= 10) out.ratingGte = rg;
-
+  const yg = clampInRange(r["yearGte"], 1900, 2100);
+  if (yg !== undefined) out.yearGte = Math.round(yg);
+  const yl = clampInRange(r["yearLte"], 1900, 2100);
+  if (yl !== undefined) out.yearLte = Math.round(yl);
+  const rg = clampInRange(r["ratingGte"], 0, 10);
+  if (rg !== undefined) out.ratingGte = rg;
   return out;
 };
 
-const json = (data: unknown, status = 200): Response =>
-  new Response(JSON.stringify(data), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
-
 export default async function handler(req: Request): Promise<Response> {
-  if (req.method !== "POST") {
-    return json({ error: "method not allowed" }, 405);
-  }
-
-  const apiKey = process.env["GROQ_API_KEY"];
-  if (!apiKey) {
-    return json({ error: "GROQ_API_KEY not configured" }, 503);
-  }
+  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
 
   let body: unknown;
   try {
@@ -145,77 +116,18 @@ export default async function handler(req: Request): Promise<Response> {
 
   const genreIds = new Set(body.genres.map((g) => g.id));
 
-  let groqRes: Response;
-  try {
-    groqRes = await fetch(GROQ_URL, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: MODEL,
-        temperature: 0.2,
-        response_format: { type: "json_object" },
-        messages: [
-          { role: "system", content: SYSTEM_PROMPT(body.domain, body.genres) },
-          { role: "user", content: body.query },
-        ],
-      }),
-    });
-  } catch (err) {
-    // Log internally (Vercel function logs) — never expose stack/error
-    // details to clients (CodeQL: js/stack-trace-exposure).
-    console.error("[/api/ai/translate] groq fetch failed:", err);
-    return json({ error: "upstream unavailable" }, 502);
-  }
-
-  if (!groqRes.ok) {
-    const text = await groqRes.text().catch(() => "");
-    console.error(
-      `[/api/ai/translate] groq returned ${groqRes.status}:`,
-      text.slice(0, 500),
-    );
-    return json({ error: "upstream error" }, 502);
-  }
-
-  let completion: unknown;
-  try {
-    completion = await groqRes.json();
-  } catch (err) {
-    console.error("[/api/ai/translate] groq returned non-json:", err);
-    return json({ error: "upstream parse error" }, 502);
-  }
-
-  const content = (
-    completion as {
-      choices?: { message?: { content?: string } }[];
-    }
-  )?.choices?.[0]?.message?.content;
-
-  if (typeof content !== "string") {
-    console.error("[/api/ai/translate] groq response missing content");
-    return json({ error: "upstream malformed" }, 502);
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(content);
-  } catch (err) {
-    console.error(
-      "[/api/ai/translate] model returned invalid json:",
-      err,
-      "content:",
-      content.slice(0, 500),
-    );
-    return json({ error: "model output invalid" }, 502);
-  }
+  const groqResult = await callGroqJson({
+    tag: TAG,
+    systemPrompt: SYSTEM_PROMPT(body.domain, body.genres),
+    userPrompt: body.query,
+  });
+  if (groqResult.kind === "error") return groqResult.response;
 
   let result: TranslateResponse;
   try {
-    result = sanitize(parsed, genreIds);
+    result = sanitize(groqResult.parsed, genreIds);
   } catch (err) {
-    console.error("[/api/ai/translate] sanitize failed:", err);
+    console.error(`[${TAG}] sanitize failed:`, err);
     return json({ error: "model output invalid" }, 502);
   }
 

--- a/src/features/today/ForYouRail.tsx
+++ b/src/features/today/ForYouRail.tsx
@@ -1,0 +1,99 @@
+import { useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { Sparkles } from "lucide-react";
+import { useAiRecommend } from "@/shared/api/ai/recommend";
+import { useDiscover, useGenres } from "@/shared/api/tmdb/hooks";
+import type { MediaItem } from "@/shared/schemas/media";
+import { useWatchlistStore } from "@/shared/store/watchlist";
+import { MediaCard } from "@/shared/components/MediaCard";
+import { MediaCardSkeleton } from "@/shared/components/MediaCardSkeleton";
+import { RailCarousel } from "@/shared/components/RailCarousel";
+
+const MIN_WATCHLIST_FOR_PERSONALIZATION = 2;
+
+/**
+ * AI-powered "For you" rail. Sends a summary of the user's watchlist to the
+ * Groq-backed /api/ai/recommend endpoint, gets back a TMDB discover filter
+ * + a one-sentence reason, then runs the filter through useDiscover to
+ * surface real items. Auto-runs on mount, cached 24h per profile signature.
+ *
+ * Hidden when the watchlist is too thin for meaningful personalization —
+ * Trending and Hero already cover the cold-start case on /today.
+ */
+export function ForYouRail() {
+  const navigate = useNavigate();
+  const entries = useWatchlistStore((s) =>
+    Object.values(s.entries).filter((e) => e.domain === "movie"),
+  );
+
+  const genres = useGenres("movie");
+  const watchlistSummary = useMemo(
+    () =>
+      entries.slice(0, 20).map((e) => {
+        const summary: {
+          title: string;
+          genres: string[];
+          year?: number;
+          status: typeof e.status;
+          rating?: number;
+        } = {
+          title: e.snapshot.title,
+          genres: e.snapshot.genres,
+          status: e.status,
+        };
+        if (e.snapshot.year !== undefined) summary.year = e.snapshot.year;
+        if (e.rating !== undefined) summary.rating = e.rating;
+        return summary;
+      }),
+    [entries],
+  );
+
+  const hasEnoughSignal = entries.length >= MIN_WATCHLIST_FOR_PERSONALIZATION;
+  const enabled = Boolean(genres.data) && hasEnoughSignal;
+
+  const recommend = useAiRecommend(
+    {
+      domain: "movie",
+      genres: genres.data ?? [],
+      watchlist: watchlistSummary,
+      recents: [],
+    },
+    enabled,
+  );
+
+  const discover = useDiscover("movie", recommend.data?.filters ?? {});
+  const items: MediaItem[] = (discover.data ?? []).slice(0, 12);
+  const isLoading = recommend.isLoading || discover.isLoading;
+
+  if (!hasEnoughSignal) return null;
+  // If the AI failed, fail closed — Trending Movies below covers the gap.
+  if (recommend.isError) return null;
+  // If discover came back empty, also fail closed.
+  if (!isLoading && items.length === 0) return null;
+
+  const open = (item: MediaItem) => {
+    const id = item.id.split(":").pop();
+    if (item.domain === "movie") navigate(`/movies/${id}`);
+    else if (item.domain === "tv") navigate(`/tv/${id}`);
+  };
+
+  return (
+    <div className="space-y-1">
+      <RailCarousel title="For you">
+        {isLoading
+          ? Array.from({ length: 6 }, (_, i) => `for-you-skel-${i}`).map(
+              (key) => <MediaCardSkeleton key={key} />,
+            )
+          : items.map((item) => (
+              <MediaCard key={item.id} item={item} onOpen={open} />
+            ))}
+      </RailCarousel>
+      {recommend.data?.reason ? (
+        <p className="flex items-start gap-1.5 px-1 text-xs text-muted">
+          <Sparkles className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
+          <span>{recommend.data.reason}</span>
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/today/TodayPage.tsx
+++ b/src/features/today/TodayPage.tsx
@@ -13,6 +13,7 @@ import { EmptyState } from "@/shared/components/EmptyState";
 import { ErrorBoundary } from "@/shared/components/ErrorBoundary";
 import { labelForRelease } from "@/features/releases/labelForRelease";
 import { releaseRoute } from "@/features/releases/releaseRoute";
+import { ForYouRail } from "./ForYouRail";
 import { pickHero } from "./heroPick";
 import type { MediaItem } from "@/shared/schemas/media";
 import { AlertCircle } from "lucide-react";
@@ -147,6 +148,9 @@ export function TodayPage() {
         }
       >
         <HeroBlock onOpen={open} />
+      </ErrorBoundary>
+      <ErrorBoundary fallback={null}>
+        <ForYouRail />
       </ErrorBoundary>
       <ErrorBoundary
         fallback={

--- a/src/shared/api/ai/recommend.test.tsx
+++ b/src/shared/api/ai/recommend.test.tsx
@@ -1,0 +1,63 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import type { ReactNode } from "react";
+import { useAiRecommend } from "./recommend";
+
+const wrap = () => {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: Readonly<{ children: ReactNode }>) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useAiRecommend", () => {
+  test("idle when enabled is false", () => {
+    const { result } = renderHook(
+      () =>
+        useAiRecommend(
+          { domain: "movie", genres: [], watchlist: [], recents: [] },
+          false,
+        ),
+      { wrapper: wrap() },
+    );
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+
+  test("returns filters + reason when enabled", async () => {
+    const { result } = renderHook(
+      () =>
+        useAiRecommend(
+          {
+            domain: "movie",
+            genres: [{ id: 878, name: "Science Fiction" }],
+            watchlist: [
+              {
+                title: "The Matrix",
+                genres: ["sci-fi", "action"],
+                year: 1999,
+                status: "done",
+                rating: 5,
+              },
+              {
+                title: "Arcane",
+                genres: ["animation", "action"],
+                year: 2021,
+                status: "in_progress",
+                rating: 5,
+              },
+            ],
+            recents: [],
+          },
+          true,
+        ),
+      { wrapper: wrap() },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.filters.genres).toContain(878);
+    expect(typeof result.current.data?.reason).toBe("string");
+    expect((result.current.data?.reason ?? "").length).toBeGreaterThan(0);
+  });
+});

--- a/src/shared/api/ai/recommend.ts
+++ b/src/shared/api/ai/recommend.ts
@@ -1,0 +1,121 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import type { DiscoverFilters } from "@/shared/api/tmdb/client";
+import type { TmdbGenre } from "@/shared/api/tmdb/schemas";
+import type { WatchlistEntry } from "@/shared/store/watchlist";
+
+interface WatchlistSummary {
+  title: string;
+  genres: string[];
+  year?: number;
+  status: WatchlistEntry["status"];
+  rating?: number;
+}
+
+export interface RecommendInput {
+  domain: "movie" | "tv";
+  genres: TmdbGenre[];
+  watchlist: WatchlistSummary[];
+  recents: string[];
+}
+
+export interface AiRecommendation {
+  filters: DiscoverFilters;
+  reason: string;
+}
+
+class AiRecommendError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "AiRecommendError";
+    this.status = status;
+  }
+}
+
+const isResponseShape = (
+  data: unknown,
+): data is {
+  filters: {
+    genres: number[];
+    yearGte?: number;
+    yearLte?: number;
+    ratingGte?: number;
+  };
+  reason: string;
+} => {
+  if (typeof data !== "object" || data === null) return false;
+  const d = data as Record<string, unknown>;
+  if (typeof d["reason"] !== "string") return false;
+  if (typeof d["filters"] !== "object" || d["filters"] === null) return false;
+  const f = d["filters"] as Record<string, unknown>;
+  return Array.isArray(f["genres"]);
+};
+
+const summarizeForServer = (input: RecommendInput): RecommendInput => ({
+  ...input,
+  watchlist: input.watchlist.slice(0, 20),
+  recents: input.recents.slice(0, 20),
+});
+
+export const aiRecommend = async (
+  input: RecommendInput,
+  signal?: AbortSignal,
+): Promise<AiRecommendation> => {
+  const res = await fetch("/api/ai/recommend", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(summarizeForServer(input)),
+    ...(signal ? { signal } : {}),
+  });
+  if (!res.ok) {
+    let detail = "";
+    try {
+      detail = await res.text();
+    } catch {
+      /* ignore */
+    }
+    throw new AiRecommendError(res.status, detail || res.statusText);
+  }
+  const data: unknown = await res.json();
+  if (!isResponseShape(data)) {
+    throw new AiRecommendError(0, "invalid response shape");
+  }
+  const filters: DiscoverFilters = { genres: data.filters.genres };
+  if (data.filters.yearGte !== undefined) filters.yearGte = data.filters.yearGte;
+  if (data.filters.yearLte !== undefined) filters.yearLte = data.filters.yearLte;
+  if (data.filters.ratingGte !== undefined) filters.ratingGte = data.filters.ratingGte;
+  return { filters, reason: data.reason };
+};
+
+/**
+ * Cache-key fingerprint of the user's profile. When the profile is the
+ * same shape (titles in same order, same status/rating), we reuse the AI
+ * result instead of re-prompting. localStorage cache lives across reloads;
+ * TanStack Query keys it for the in-memory layer.
+ */
+const fingerprint = (input: RecommendInput): string => {
+  const wl = input.watchlist
+    .map((e) => `${e.title}|${e.status}|${e.rating ?? ""}`)
+    .join("/");
+  const rc = input.recents.join("/");
+  return `${input.domain}::wl(${wl})::rc(${rc})`;
+};
+
+const DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Auto-runs once the input is non-empty; cached aggressively. Pass
+ * `enabled: false` to suppress (e.g. while the inputs are still loading).
+ */
+export const useAiRecommend = (
+  input: RecommendInput,
+  enabled: boolean,
+): UseQueryResult<AiRecommendation> =>
+  useQuery({
+    queryKey: ["ai", "recommend", fingerprint(input)],
+    queryFn: ({ signal }) => aiRecommend(input, signal),
+    staleTime: DAY,
+    gcTime: 2 * DAY,
+    enabled,
+    retry: false,
+  });

--- a/src/test/handlers.ts
+++ b/src/test/handlers.ts
@@ -82,4 +82,13 @@ export const handlers: HttpHandler[] = [
       yearLte: 1999,
     }),
   ),
+
+  // AI personalized recommend — deterministic stub mirroring translate's
+  // shape (filters + reason).
+  http.post("/api/ai/recommend", () =>
+    HttpResponse.json({
+      filters: { genres: [878, 28], yearGte: 2015, ratingGte: 7 },
+      reason: "Lean into the cerebral sci-fi action vibe from your watchlist.",
+    }),
+  ),
 ];


### PR DESCRIPTION
## Summary

Adds an AI-powered personalized rail to `/today` that surfaces movies tailored to your local watchlist.

Flow:
1. `ForYouRail` reads your movie watchlist from the Zustand store (titles, genres, years, statuses, ratings).
2. Sends a 20-item summary to **`/api/ai/recommend`** — new Vercel Edge function.
3. Edge function asks **Groq Llama 3.1 8B Instant** to pick a TMDB discover filter (genres + optional year window + optional rating floor) plus a one-sentence reason.
4. Server-side sanitize: genre IDs filtered to allowed set, years clamped 1900–2100, rating 0–10.
5. Client takes the filters, runs `tmdb.discover()` through the existing hook, renders results in a `RailCarousel`.
6. The AI's reason renders as a small subtitle below the rail: e.g. *"✨ Lean into the cerebral sci-fi action vibe from your watchlist."*

## Cold-start handling

Hidden entirely when watchlist has < 2 entries. Trending + Hero already cover the empty case. No noisy "add things to get recs" CTAs.

## Caching

Cache key is a **fingerprint of the profile** (title + status + rating per entry). Same profile → reuse the AI's previous answer (24h staleTime, 2-day gcTime). Add a new title or change a status → re-prompt.

## Fail-closed UX

If Groq errors, the network drops, or discover returns empty — the rail just disappears. No half-broken state, no error popup on the home page. The page's other rails carry the load.

## Privacy

- Only titles, genres, years, statuses, ratings sent server-side.
- No session IDs, no auth header (no accounts), no namespaced TMDB IDs.
- The Edge function persists nothing — pure passthrough to Groq + sanitize.
- Errors logged server-side (Vercel function logs), generic to clients (same security pattern as `/api/ai/translate`).

## Setup

The endpoint reuses the same `GROQ_API_KEY` env var as `/api/ai/translate`. If you already added it locally and on Vercel for the previous PR, nothing else to do.

## Tests

- 1 new `useAiRecommend` hook test (idle / returns shape).
- MSW handler for `/api/ai/recommend` keeps every other test deterministic.
- **178 unit tests passing** (was 176).

## Out of scope

- Sending the taste store's `recentItems` to the AI — currently sent as `[]` because the store keeps namespaced IDs without titles, and joining each back to a title would be N extra TMDB lookups per render.
- "Refresh recommendations" manual button. The cache invalidates on profile change; a manual override is easy to add later.
- TV recs (currently `domain: "movie"` only; same architecture would work for tv).

## Test plan

- [ ] Local dev: `npm run dev` with `GROQ_API_KEY` set in `.env.local`
- [ ] Add at least 2 movies to watchlist
- [ ] Visit `/today` → "For you" rail appears between hero and Trending Movies
- [ ] The reason line below the rail references something specific to your watchlist
- [ ] Watchlist with 0 or 1 items → rail hidden
- [ ] Network → block `/api/ai/recommend` → rail hidden, no console errors visible to user
- [ ] Add a new movie to watchlist → rail re-prompts AI (cache key changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)