### PR TITLE
TMDB proxy: per-endpoint CDN cache policy + dev TLS warning

### DIFF
--- a/api/tmdb.ts
+++ b/api/tmdb.ts
@@ -40,10 +40,53 @@ const ALLOWED_PREFIXES = [
   "genre/tv/list",
 ] as const;
 
+// Per-endpoint Vercel CDN cache TTLs. `s-maxage` is the CDN cache lifetime
+// (Vercel's shared cache); `stale-while-revalidate` is how long the CDN can
+// keep serving the stale response while it refreshes in the background. The
+// values mirror the client-side TanStack Query `staleTime` from hooks.ts so
+// the two layers don't fight.
+//
+// IMPORTANT: `max-age` is intentionally omitted. We want the CDN to cache
+// (s-maxage) without locking the browser's private cache; TanStack Query
+// owns client-side invalidation.
+interface CachePolicy {
+  sMaxage: number;
+  staleWhileRevalidate: number;
+}
+
+const MINUTE = 60;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+const POLICIES: { match: (p: string) => boolean; policy: CachePolicy }[] = [
+  // Effectively static: genre lists rarely change.
+  { match: (p) => p === "genre/movie/list" || p === "genre/tv/list", policy: { sMaxage: 7 * DAY, staleWhileRevalidate: 30 * DAY } },
+  // Search depends on user input — short cache so typos roll off quickly.
+  { match: (p) => p.startsWith("search/movie") || p.startsWith("search/tv"), policy: { sMaxage: 5 * MINUTE, staleWhileRevalidate: 1 * HOUR } },
+  // Trending refreshes hourly.
+  { match: (p) => p.startsWith("trending/movie/") || p.startsWith("trending/tv/"), policy: { sMaxage: 1 * HOUR, staleWhileRevalidate: 6 * HOUR } },
+  // Discover (filter-driven lists) — same as trending.
+  { match: (p) => p.startsWith("discover/"), policy: { sMaxage: 1 * HOUR, staleWhileRevalidate: 6 * HOUR } },
+  // Details / similar / recommendations / watch providers — stable per title.
+  { match: (p) => p.startsWith("movie/") || p.startsWith("tv/"), policy: { sMaxage: 1 * DAY, staleWhileRevalidate: 7 * DAY } },
+];
+
+// Conservative fallback for anything not explicitly mapped.
+const FALLBACK_POLICY: CachePolicy = { sMaxage: 5 * MINUTE, staleWhileRevalidate: 1 * HOUR };
+
+const cachePolicyFor = (path: string): CachePolicy =>
+  POLICIES.find((p) => p.match(path))?.policy ?? FALLBACK_POLICY;
+
+const cacheHeaderFor = (path: string): string => {
+  const { sMaxage, staleWhileRevalidate } = cachePolicyFor(path);
+  return `public, s-maxage=${sMaxage}, stale-while-revalidate=${staleWhileRevalidate}`;
+};
+
 const json = (data: unknown, status: number): Response =>
   new Response(JSON.stringify(data), {
     status,
-    headers: { "content-type": "application/json" },
+    // Errors must never be cached — a transient 502 shouldn't poison the CDN.
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
   });
 
 const isAllowed = (path: string): boolean =>
@@ -86,14 +129,16 @@ export default async function handler(req: Request): Promise<Response> {
     return json({ error: "upstream unavailable" }, 502);
   }
 
-  // Forward the body and status. Strip the upstream's set-cookie just in
-  // case (TMDB doesn't set any, but defensive). Preserve content-type and
-  // add a short shared cache TTL so Vercel's edge can collapse repeated
-  // requests from different users.
+  // Forward the body verbatim. Preserve content-type. For 2xx responses,
+  // apply the per-endpoint Vercel CDN cache policy; for non-2xx, set
+  // `no-store` so transient failures don't pollute the shared cache.
   const headers = new Headers();
   const contentType = upstream.headers.get("content-type");
   if (contentType) headers.set("content-type", contentType);
-  headers.set("cache-control", "public, s-maxage=60, stale-while-revalidate=300");
+  headers.set(
+    "cache-control",
+    upstream.ok ? cacheHeaderFor(path) : "no-store",
+  );
 
   return new Response(upstream.body, { status: upstream.status, headers });
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,20 @@ const apiHandlers = (): Plugin => ({
       if (process.env[key] === undefined) process.env[key] = value;
     }
 
+    // Heads-up for anyone running `npm run dev` behind a corporate SSL-
+    // inspection proxy (Zscaler / Netskope / etc.). Node's fetch uses its
+    // bundled CA list — not the OS keychain — so HTTPS calls from the
+    // edge functions (TMDB, Groq) fail with "unable to get local issuer
+    // certificate" unless NODE_EXTRA_CA_CERTS is set or Node ≥22 was
+    // launched with --use-system-ca. Print a single warning at startup
+    // so the symptom (502 "upstream unavailable") doesn't waste another
+    // debugging session.
+    if (!process.env["NODE_EXTRA_CA_CERTS"] && !process.execArgv.includes("--use-system-ca")) {
+      console.warn(
+        "[vercel-api-dev] NODE_EXTRA_CA_CERTS not set. If you're behind a corporate SSL-inspection proxy, edge-function HTTPS calls (TMDB, Groq) will fail with 502. Fix: export NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.pem before `npm run dev`.",
+      );
+    }
+
     server.middlewares.use(async (req, res, next) => {
       const url = req.url ?? "";
       if (!url.startsWith("/api/")) return next();


### PR DESCRIPTION
## Summary

Finishes the TMDB proxy migration with the caching policy from the design.

**Before:** every `/api/tmdb/<path>` response carried the same blanket header `Cache-Control: public, s-maxage=60, stale-while-revalidate=300`. This was barely better than no caching for static endpoints (genre list re-fetched every 60 s) and also cached transient errors at the CDN.

**After:** a small lookup table inside `api/tmdb.ts` returns an endpoint-appropriate `Cache-Control` per request. Errors get `no-store`.

| Path pattern | `s-maxage` | `stale-while-revalidate` |
|---|---:|---:|
| `genre/{movie,tv}/list` | 7 d | 30 d |
| `search/{movie,tv}` | 5 m | 1 h |
| `trending/{movie,tv}/*` | 1 h | 6 h |
| `discover/{movie,tv}` | 1 h | 6 h |
| `movie/*`, `tv/*` (details, similar, recommendations, watch providers) | 1 d | 7 d |
| fallback | 5 m | 1 h |

The values mirror the client-side `staleTime` values in `src/shared/api/tmdb/hooks.ts` so the two cache layers don't fight.

**Why `s-maxage` and not `max-age`** — `max-age` would pin responses in the browser's private cache, fighting TanStack Query's invalidation. We want the *shared* CDN layer to cache (so 50 users hitting `/trending/movie/day` only hit TMDB once an hour) while letting Query own the per-tab freshness story.

## Dev-time TLS warning

Adds a startup log in the `apiHandlers` Vite plugin: if `NODE_EXTRA_CA_CERTS` is unset and Node wasn't launched with `--use-system-ca`, prints a one-line hint. Behind a corporate SSL-inspection proxy (Zscaler / Netskope / Cisco Umbrella), Node's fetch can't validate upstream certs and fails with `unable to get local issuer certificate` — which our edge function reports as a generic 502. The warning short-circuits future debugging sessions.

```
[vercel-api-dev] NODE_EXTRA_CA_CERTS not set. If you're behind a corporate
SSL-inspection proxy, edge-function HTTPS calls (TMDB, Groq) will fail with
502. Fix: export NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.pem before
`npm run dev`.
```

Surfaces once per dev-server start, not per request — quiet enough to ignore when not relevant.

## Out of scope

- No client changes. `src/shared/api/tmdb/client.ts` already uses `/api/tmdb` as `BASE`.
- No changes to MSW handlers or Workbox runtime caching (both already target `/api/tmdb/*` from earlier work).
- TLS cert fix itself is not in this PR — the warning just points at it. That's a per-developer-machine setup, not a code change.

## Test plan

- [ ] CI green
- [ ] Vercel preview: `curl -sI https://<preview>/api/tmdb/genre/movie/list` returns `cache-control: public, s-maxage=604800, stale-while-revalidate=2592000`
- [ ] `curl -sI https://<preview>/api/tmdb/search/movie?query=matrix` returns `s-maxage=300`
- [ ] Second hit shows `x-vercel-cache: HIT`
- [ ] 4xx upstream (e.g., `/api/tmdb/movie/999999999`) returns the same status with `cache-control: no-store`
- [ ] Locally with `NODE_EXTRA_CA_CERTS` set: `/api/tmdb/trending/movie/day` returns 200 with the per-endpoint header

🤖 Generated with [Claude Code](https://claude.com/claude-code)